### PR TITLE
Fix CVE-2017-17485 and add support for OCP 3.11 and 3.10

### DIFF
--- a/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryController.java
+++ b/openshift/recovery-controller/src/main/java/me/snowdrop/boot/narayana/openshift/recovery/StatefulsetRecoveryController.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.extensions.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.slf4j.Logger;

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>2.20.0</mockito.version>
     <narayana.version>5.8.0.Final</narayana.version>
-    <openshift-client.version>3.1.8</openshift-client.version>
+    <openshift-client.version>4.1.2</openshift-client.version>
     <spring-boot.version>1.5.12.RELEASE</spring-boot.version>
     <spring.version>4.3.16.RELEASE</spring.version>
     <transaction-api.version>1.2</transaction-api.version>


### PR DESCRIPTION
Fixes [ENTESB-9892](https://issues.jboss.org/browse/ENTESB-9892)

Also seems we needed to upgrade openshift-client as we want to [support](https://access.redhat.com/articles/310603#Red-Hat-Fuse-72) OCP 3.10 .3.11 which requires [4.1.x](https://github.com/fabric8io/kubernetes-client) 