### PR TITLE
Remove unnecessary plugins from release profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,16 +280,6 @@
   <profiles>
     <profile>
       <id>release</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-      </distributionManagement>
       <build>
         <plugins>
           <plugin>
@@ -315,55 +305,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <!--
-              Needed to bypass the encoding of the passphrase when task is executed by a job and not a human
-              Syntax could change with future releases of the plugin (after 3.0.0)
-            -->
-            <configuration>
-              <useAgent>true</useAgent>
-              <passphrase>${env.GPG_PASSPHRASE}</passphrase>
-              <gpgArguments>
-                <arg>--batch</arg>
-                <arg>--pinentry-mode</arg>
-                <arg>loopback</arg>
-              </gpgArguments>
-            </configuration>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-release-plugin</artifactId>
-            <configuration>
-              <autoVersionSubmodules>true</autoVersionSubmodules>
-              <useReleaseProfile>false</useReleaseProfile>
-              <releaseProfiles>release</releaseProfiles>
-              <goals>deploy</goals>
-            </configuration>
-          </plugin>
-          <plugin>
-            <!--See http://central.sonatype.org/pages/apache-maven.html for more information -->
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Getting errors on the maven-nexus-staging-plugin - for the 7.x build we have removed a number of the plugins.      I'd like to remove gpg-plugin, nexus-maven-staging-plugin, and release plugin (none of which are necessary for our PNC builds)

https://orch.psi.redhat.com/pnc-web/#/projects/157/build-configs/8124/builds/ASWVJIEZPQAAA/build-log