### PR TITLE
Use camel.version for camel-test-spring-junit5 as that artifact comes from camel (#113)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <agroal.version>2.2</agroal.version>
     <awaitility.version>4.2.0</awaitility.version>
     <byteman.version>4.0.21</byteman.version>
+    <camel.version>4.0.0</camel.version>
     <camel-spring-boot.version>4.0.0</camel-spring-boot.version>
     <narayana.version>6.0.1.Final</narayana.version>
     <openshift-client.version>6.7.2</openshift-client.version>
@@ -115,7 +116,7 @@
       <dependency>
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
-        <version>${camel-spring-boot.version}</version>
+        <version>${camel.version}</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>


### PR DESCRIPTION
Cherry-picked from upstream snowdrop/narayana-spring-boot - we need separate versions for camel/camel-spring-boot