### PR TITLE
Add a dependency management entry for agroal so it is aligned correctly in future

### DIFF
--- a/narayana-spring-boot-starter-it/pom.xml
+++ b/narayana-spring-boot-starter-it/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-spring-boot-starter</artifactId>
-        <version>${agroal.version}</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,11 @@
         <artifactId>byteman-bmunit5</artifactId>
         <version>${byteman.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.agroal</groupId>
+        <artifactId>agroal-spring-boot-starter</artifactId>
+        <version>${agroal.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
PME doesn't seem to be aligning agroal, and I think it is because the only place where there is a depedency is in the integration test.     Add a dependency management entry for agroal so that we align correctly.