### PR TITLE
Revert "Align the camel version to 4.8.3.redhat-00002."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <agroal.version>2.5</agroal.version>
     <awaitility.version>4.2.2</awaitility.version>
     <byteman.version>4.0.21</byteman.version>
-    <camel.version>4.8.3.redhat-00002</camel.version>
+    <camel.version>4.8.0.redhat-00001</camel.version>
     <camel-spring-boot.version>4.7.0</camel-spring-boot.version>
     <narayana.version>7.0.2.Final</narayana.version>
     <openshift-client.version>6.13.1</openshift-client.version>


### PR DESCRIPTION
Reverting commit eb361d2723ab1fc578ca10b87603c93b0513468b - this was meant for the camel-4.8.3-branch, not the camel-4.8.0-branch