### PR TITLE
Upgrade openshift-client to 7.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <camel.version>4.10.6.redhat-00003</camel.version>
     <camel-spring-boot.version>4.10.6</camel-spring-boot.version>
     <narayana.version>7.1.0.Final</narayana.version>
-    <openshift-client.version>6.13.4</openshift-client.version>
+    <openshift-client.version>7.3.1</openshift-client.version>
     <spring-boot.version>3.4.8</spring-boot.version>
 
     <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Upgrade openshift-client to 7.3.1, which would bring okio use to version 3.6.0 and align openshift-client with the version of kubernetes-client being used by camel (7.3.1).    

I've checked through the narayana-spring-boot upstream commit logs and there don't appear to be any changes related to the upgrades of openshift-client from 6.13.4->7.3.1.     

Ran tests locally and they all passed.