### PR TITLE
Newly create 4.10.7 branch - upgrade to spring-boot 3.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <camel-spring-boot.version>4.10.6</camel-spring-boot.version>
     <narayana.version>7.2.2.Final</narayana.version>
     <openshift-client.version>7.3.1</openshift-client.version>
-    <spring-boot.version>3.4.7</spring-boot.version>
+    <spring-boot.version>3.4.10</spring-boot.version>
 
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>


### PR DESCRIPTION
camel 4.10.7 isn't out yet but we can upgrade the downstream projects to spring-boot 3.4.10