### PR TITLE
Upgrade spring-boot version to 3.5.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,20 +57,20 @@
     <camel-spring-boot.version>4.18.1</camel-spring-boot.version>
     <narayana.version>7.2.2.Final</narayana.version>
     <openshift-client.version>7.3.1</openshift-client.version>
-    <spring-boot.version>3.5.14</spring-boot.version>
+    <spring-boot.version>3.5.15</spring-boot.version>
     <vertx.version>4.5.24</vertx.version>
 
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.11.3</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Summary
- Upgrade Spring Boot from 3.5.14 to 3.5.15
- Align Maven plugin versions with Spring Boot 3.5.15 BOM: maven-compiler-plugin (3.14.1), maven-failsafe-plugin (3.5.6), maven-javadoc-plugin (3.11.3), maven-surefire-plugin (3.5.6)