### PR TITLE
Align to spring-boot 4.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,19 +58,19 @@
     <checkstyle.version>12.3.1</checkstyle.version>
     <narayana.version>7.3.3.Final</narayana.version>
     <openshift-client.version>7.4.0</openshift-client.version>
-    <spring-boot.version>4.0.6</spring-boot.version>
+    <spring-boot.version>4.0.7</spring-boot.version>
 
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
+    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+    <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
## Summary
- Bump `spring-boot.version` from 4.0.6 to 4.0.7
- Align `maven-enforcer-plugin` (3.6.2 → 3.6.3), `maven-failsafe-plugin` (3.5.4 → 3.5.6), and `maven-surefire-plugin` (3.5.4 → 3.5.6) to match the Spring Boot 4.0.7 BOM