### PR TITLE
Bump Vert.x from 4.5.28 to 4.5.30 (CVE-2026-15075, CVE-2026-15076)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <narayana.version>7.2.2.Final</narayana.version>
     <openshift-client.version>7.3.1</openshift-client.version>
     <spring-boot.version>3.5.16</spring-boot.version>
-    <vertx.version>4.5.28</vertx.version>
+    <vertx.version>4.5.30</vertx.version>
 
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>


### PR DESCRIPTION
## Summary
- Bumps Vert.x version from 4.5.28 to 4.5.30
- Fixes CVE-2026-15075 (`io.vertx:vertx-core`, affected < 4.5.30)
- Fixes CVE-2026-15076 (`io.vertx:vertx-web-client`, affected < 4.5.30)

## Dependency tree verification
All vertx artifacts resolve to 4.5.30:
- `io.vertx:vertx-core:4.5.30`
- `io.vertx:vertx-web-client:4.5.30`
- `io.vertx:vertx-web:4.5.30`
- `io.vertx:vertx-web-common:4.5.30`
- `io.vertx:vertx-auth-common:4.5.30`
- `io.vertx:vertx-bridge-common:4.5.30`

## Test plan
- [x] Full build (`mvn clean install -DskipTests`) — SUCCESS
- [x] `narayana-spring-boot-core` tests — PASSED
- [x] `narayana-spring-boot-starter` tests — PASSED
- [x] `narayana-spring-boot-starter-it` integration tests — PASSED
- [ ] `RecoveryControllerIT` — pre-existing flaky failure (same at 4.5.28), unrelated to this change